### PR TITLE
fix: use correct dev command for bun template

### DIFF
--- a/packages/create-pylon/templates/bun/default/package.json
+++ b/packages/create-pylon/templates/bun/default/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Generated with `npm create pylon`",
   "scripts": {
-    "dev": "pylon dev -c 'node --enable-source-maps .pylon/index.js'",
+    "dev": "pylon dev -c 'bun run .pylon/index.js'",
     "build": "pylon build"
   },
   "dependencies": {


### PR DESCRIPTION
Previously, the dev command was set to `node .pylon/index.js` which is incorrect for the bun template.
The correct dev command is `bun run .pylon/index.js`.