### PR TITLE
fix: load compilerOptions from pylon tsconfig.json

### DIFF
--- a/packages/pylon-builder/src/schema/builder.ts
+++ b/packages/pylon-builder/src/schema/builder.ts
@@ -1,5 +1,6 @@
 import ts from 'typescript'
 import {SchemaParser} from './schema-parser'
+import path from 'path'
 
 export class SchemaBuilder {
   private program: ts.Program
@@ -11,16 +12,9 @@ export class SchemaBuilder {
   constructor(sfiFilePath: string) {
     this.sfiFilePath = sfiFilePath
 
-    this.program = ts.createProgram([this.sfiFilePath], {
-      target: ts.ScriptTarget.ESNext,
-      module: ts.ModuleKind.CommonJS,
-      strict: true,
-      esModuleInterop: true,
-      skipLibCheck: false,
-      forceConsistentCasingInFileNames: true,
-      noImplicitAny: true,
-      experimentalDecorators: true
-    })
+    const tsConfigOptions = this.loadTsConfigOptions()
+
+    this.program = ts.createProgram([this.sfiFilePath], tsConfigOptions)
 
     this.checker = this.program.getTypeChecker()
 
@@ -48,6 +42,48 @@ export class SchemaBuilder {
     }
 
     this.sfi = sfiFileDefaultExport
+  }
+
+  private loadTsConfigOptions() {
+    const defaultOptions: ts.CompilerOptions = {
+      target: ts.ScriptTarget.ESNext,
+      module: ts.ModuleKind.CommonJS,
+      strict: true,
+      esModuleInterop: true,
+      skipLibCheck: false,
+      forceConsistentCasingInFileNames: true,
+      noImplicitAny: true,
+      experimentalDecorators: true
+    }
+
+    // Find the tsconfig.json file
+    const configPath = ts.findConfigFile(
+      path.dirname(this.sfiFilePath), // Directory to start searching from
+      ts.sys.fileExists, // Function to check if a file exists
+      'tsconfig.json' // File name to search for
+    )
+
+    if (!configPath) {
+      console.log('Could not find tsconfig.json')
+      return defaultOptions
+    }
+
+    // Read the tsconfig.json file
+    const configFile = ts.readConfigFile(configPath, ts.sys.readFile)
+
+    if (configFile.error) {
+      console.log('Could not read tsconfig.json', configFile.error)
+      return defaultOptions
+    }
+
+    // Parse the tsconfig.json file
+    const parsedConfig = ts.parseJsonConfigFileContent(
+      configFile.config,
+      ts.sys,
+      path.dirname(configPath)
+    )
+
+    return parsedConfig.options
   }
 
   public build() {


### PR DESCRIPTION
This fixes a issue where the path aliases defined in the `tsconfig.json` of the pylon were not being loaded when generating the schema.

This was because the `compilerOptions` were defined inside the SchemaBuilder, and not being loaded from the `tsconfig.json` file.

Now the `tsconfig.json` file is loaded and the pre-defined `compilerOptions` are only used as a fallback.

Closes #15

![image](https://github.com/user-attachments/assets/b8ccdca2-f423-49c7-9d44-6b941731456b)
![image](https://github.com/user-attachments/assets/3fcb3819-ebe3-4edd-9ee3-1cdc5f3b449b)
![image](https://github.com/user-attachments/assets/0557b529-4ef7-4521-a3c5-4185a2424884)
![image](https://github.com/user-attachments/assets/7209e1ae-5ebf-4b06-a435-6f93e0b3b4f7)
