### PR TITLE
feat(create-pylon): add support for Deno runtime

### DIFF
--- a/docs/pages/docs/faq.mdx
+++ b/docs/pages/docs/faq.mdx
@@ -105,4 +105,4 @@ If you encounter any issues or have suggestions for improvement, please feel fre
 ~~Currently, Pylon supports the [Bun](https://bun.sh) runtime. However, we have a open issue to support this [Runtimes](https://hono.dev/docs/getting-started/basic).~~
 ~~If you would like to see support for other runtimes, please let us know by upvoting [this issue](https://github.com/getcronit/pylon/issues/6) on GitHub.~~
 
-As of Pylon v2, the framework now supports multiple runtimes, including Bun, Node.js and Cloudflare Workers. Other runtimes are also supported but require manual setup. For more information on the supported runtimes, refer to the [release notes](/docs/release-notes/v2.0.mdx).
+As of Pylon v2, the framework now supports multiple runtimes, including Bun, Node.js, Cloudflare Workers and Deno. Other runtimes are also supported but require manual setup. For more information on the supported runtimes, refer to the [release notes](/docs/release-notes/v2.0.mdx).

--- a/docs/pages/docs/getting-started.mdx
+++ b/docs/pages/docs/getting-started.mdx
@@ -51,8 +51,8 @@ npm create pylon my-pylon@latest
 ```
 
 <Callout type="note" title="Info">
-  Pylon now supports multiple runtimes, including Node.js, Bun and Cloudflare
-  Workers.
+  Pylon now supports multiple runtimes, including Node.js, Bun, Cloudflare
+  Workers, and Deno.
 </Callout>
 
 This will create a new directory called `my-pylon` with a basic Pylon project structure.

--- a/packages/create-pylon/package.json
+++ b/packages/create-pylon/package.json
@@ -24,7 +24,6 @@
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
     "consola": "^3.2.3",
-    "detect-package-manager": "^3.0.2",
     "@getcronit/pylon-telemetry": "^1.0.0"
   },
   "engines": {

--- a/packages/create-pylon/src/detect-pm.ts
+++ b/packages/create-pylon/src/detect-pm.ts
@@ -1,0 +1,145 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import process from 'node:process'
+import {execSync} from 'node:child_process'
+import consola from 'consola'
+
+// Helper function to check if a command exists
+function isCommandAvailable(command: string): boolean {
+  try {
+    execSync(`${command} --version`, {stdio: 'ignore'})
+    return true
+  } catch (e) {
+    console.error(e)
+    return false
+  }
+}
+
+// Detect Bun
+function isBun(): boolean {
+  // @ts-ignore: Bun may not be defined
+  return typeof Bun !== 'undefined' && isCommandAvailable('bun')
+}
+
+// Detect npm
+function isNpm(): boolean {
+  return process.env.npm_execpath?.includes('npm') ?? false
+}
+
+// Detect Yarn
+function isYarn(): boolean {
+  return process.env.npm_execpath?.includes('yarn') ?? false
+}
+
+// Detect Deno
+function isDeno(): boolean {
+  // @ts-ignore: Deno may not be defined
+  return typeof Deno !== 'undefined' && isCommandAvailable('deno')
+}
+
+// Detect pnpm
+function isPnpm(): boolean {
+  return process.env.npm_execpath?.includes('pnpm') ?? false
+}
+
+// Detect based on lock files
+function detectByLockFiles(cwd: string): PackageManager | null {
+  if (fs.existsSync(path.join(cwd, 'bun.lockb'))) {
+    return 'bun'
+  }
+  if (fs.existsSync(path.join(cwd, 'package-lock.json'))) {
+    return 'npm'
+  }
+  if (fs.existsSync(path.join(cwd, 'yarn.lock'))) {
+    return 'yarn'
+  }
+  if (
+    fs.existsSync(path.join(cwd, 'deno.json')) ||
+    fs.existsSync(path.join(cwd, 'deno.lock'))
+  ) {
+    return 'deno'
+  }
+  if (fs.existsSync(path.join(cwd, 'pnpm-lock.yaml'))) {
+    return 'pnpm'
+  }
+  return null
+}
+
+export type PackageManager =
+  | 'bun'
+  | 'npm'
+  | 'yarn'
+  | 'pnpm'
+  | 'deno'
+  | 'unknown'
+
+// Main detection function
+export function detectPackageManager({
+  preferredPm,
+  cwd = process.cwd()
+}: {
+  preferredPm?: PackageManager
+  cwd?: string
+}): PackageManager {
+  // Check the preferred package manager first
+  if (preferredPm && isCommandAvailable(preferredPm)) {
+    return preferredPm
+  }
+
+  // Proceed with detection logic
+  if (isBun()) {
+    return 'bun'
+  }
+  if (isNpm()) {
+    return 'npm'
+  }
+  if (isPnpm()) {
+    return 'pnpm'
+  }
+  if (isDeno()) {
+    return 'deno'
+  }
+  if (isYarn()) {
+    return 'yarn'
+  }
+
+  // Fallback to lock file detection
+  const lockFileDetection = detectByLockFiles(cwd)
+  if (lockFileDetection) {
+    consola.info(`Detected package manager by lock file: ${lockFileDetection}`)
+    if (isCommandAvailable(lockFileDetection)) {
+      return lockFileDetection
+    } else {
+      consola.warn(
+        `Lock file detected, but ${lockFileDetection} is not installed.`
+      )
+    }
+  }
+
+  return 'unknown'
+}
+
+type PackageManagerScript =
+  | 'bun'
+  | 'npm run'
+  | 'yarn'
+  | 'pnpm run'
+  | 'deno task'
+
+// Run script detection
+export function getRunScript(pm: PackageManager): PackageManagerScript {
+  switch (pm) {
+    case 'bun':
+      return 'bun'
+    case 'npm':
+      return 'npm run'
+    case 'yarn':
+      return 'yarn'
+    case 'pnpm':
+      return 'pnpm run'
+    case 'deno':
+      return 'deno task'
+    default:
+      throw new Error('Unknown package manager')
+  }
+}

--- a/packages/create-pylon/templates/deno/default/.vscode/extensions.json
+++ b/packages/create-pylon/templates/deno/default/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "denoland.vscode-deno"
+  ]
+}

--- a/packages/create-pylon/templates/deno/default/.vscode/settings.json
+++ b/packages/create-pylon/templates/deno/default/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "deno.enablePaths": [
+    "./"
+  ],
+  "editor.inlayHints.enabled": "off"
+}

--- a/packages/create-pylon/templates/deno/default/Dockerfile
+++ b/packages/create-pylon/templates/deno/default/Dockerfile
@@ -1,0 +1,12 @@
+FROM denoland/deno
+
+EXPOSE 3000
+
+WORKDIR /app
+
+ADD . /app
+
+RUN deno install
+RUN deno task build
+
+CMD ["run", "-A", ".pylon/index.js"]

--- a/packages/create-pylon/templates/deno/default/deno.json
+++ b/packages/create-pylon/templates/deno/default/deno.json
@@ -1,0 +1,15 @@
+{
+  "imports": {
+    "@getcronit/pylon-dev": "npm:@getcronit/pylon-dev@^1.0.1",
+    "@getcronit/pylon": "npm:@getcronit/pylon@^2.2.1"
+  },
+  "tasks": {
+    "dev": "pylon dev -c 'deno run -A .pylon/index.js --config tsconfig.json'",
+    "build": "pylon build"
+  },
+  "compilerOptions": {
+    "jsx": "precompile",
+    "jsxImportSource": "hono/jsx"
+  },
+  "nodeModulesDir": "auto"
+}

--- a/packages/create-pylon/templates/deno/default/src/index.ts
+++ b/packages/create-pylon/templates/deno/default/src/index.ts
@@ -1,0 +1,17 @@
+import {app} from '@getcronit/pylon'
+
+export const graphql = {
+  Query: {
+    hello: () => {
+      return 'Hello, world!'
+    }
+  },
+  Mutation: {}
+}
+
+Deno.serve(
+  {
+    port: 3000
+  },
+  app.fetch
+)

--- a/packages/pylon/README.md
+++ b/packages/pylon/README.md
@@ -152,9 +152,9 @@ docker run -p 3000:3000 my-pylon
 
 Designed to be flexible, Pylon can be run on various platforms, including:
 
-| <img src="https://bun.sh/logo.svg" width="48px" height="48px" alt="Bun.js logo"> | <img src="https://nodejs.org/static/logos/jsIconWhite.svg" width="48px" height="48px" alt="Node.JS"> | <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQgW7cAlhYN23JXGKy9Uji4Ae2mnHOR9eXX9g&s" width="48px" height="48px" alt="Gmail logo"> |
-| :------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------: |
-|                                      Bun.js                                      |                                               Node.js                                                |                                                                  Cloudflare Workers                                                                  |
+| <img src="https://bun.sh/logo.svg" width="48px" height="48px" alt="Bun.js logo"> | <img src="https://nodejs.org/static/logos/jsIconWhite.svg" width="48px" height="48px" alt="Node.JS"> | <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQgW7cAlhYN23JXGKy9Uji4Ae2mnHOR9eXX9g&s" width="48px" height="48px" alt="Gmail logo"> | <img src="https://deno.land/logo.svg" width="48px" height="48px" alt="Deno logo"> |
+| :------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------: | --------------------------------------------------------------------------------- |
+|                                      Bun.js                                      |                                               Node.js                                                |                                                                  Cloudflare Workers                                                                  | Deno                                                                              |
 
 ## Features
 


### PR DESCRIPTION
- Closes #45 
- Added support for detecting Deno as a package manager
- Created a new file, detect-pm.ts, to handle package manager detection logic
- Updated index.ts to include Deno as a runtime option
- Added Deno-specific files and configurations to the default Deno template
- Fixed success message script according to current runtime / pm. closes #43 

closes #41

