### PR TITLE
Fix broken releases and add build step to CI workflow

### DIFF
--- a/.changeset/wise-seas-chew.md
+++ b/.changeset/wise-seas-chew.md
@@ -1,0 +1,9 @@
+---
+'create-pylon': patch
+'@getcronit/pylon': patch
+'@getcronit/pylon-builder': patch
+'@getcronit/pylon-dev': patch
+'@getcronit/pylon-telemetry': patch
+---
+
+Missing build before release lead to broken packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Install Dependencies
         run: pnpm i --frozen-lockfile
 
+      - name: Build Packages
+        run: pnpm build
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "changeset": "changeset --",
-    "ci:release": "pnpm run build && changeset publish",
+    "ci:release": "changeset publish",
     "ci:version": "changeset version && pnpm i --no-frozen-lockfile --lockfile-only --ignore-scripts",
     "clean": "pnpm -r --filter \"./packages/*\" exec -- rimraf dist",
     "build": "pnpm -r --filter \"./packages/*\" run build"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "changeset": "changeset --",
-    "ci:release": "changeset publish",
+    "ci:release": "pnpm run build && changeset publish",
     "ci:version": "changeset version && pnpm i --no-frozen-lockfile --lockfile-only --ignore-scripts",
     "clean": "pnpm -r --filter \"./packages/*\" exec -- rimraf dist",
     "build": "pnpm -r --filter \"./packages/*\" run build"


### PR DESCRIPTION
Address missing build step before creating release, which resulted in broken packages. This update ensures that packages are built prior to release.