### PR TITLE
fix(builder): use property symbol instead of type property

### DIFF
--- a/.changeset/cold-snakes-listen.md
+++ b/.changeset/cold-snakes-listen.md
@@ -1,0 +1,5 @@
+---
+'@getcronit/pylon-builder': patch
+---
+
+Fix broken field descriptions in schema parsing.

--- a/packages/pylon-builder/src/schema/schema-parser.ts
+++ b/packages/pylon-builder/src/schema/schema-parser.ts
@@ -79,6 +79,7 @@ export interface Schema {
 
 type ReferenceSchemaType = {
   returnType: ts.Type
+  symbol: ts.Symbol
   args: {
     // value needs to be inputs type
     [key: string]: {
@@ -447,6 +448,7 @@ export class SchemaParser {
       }
       schemaString += ` {\n`
 
+
       // loop over the fields in the type object
       for (const field of type.fields) {
         // build the argument list for the field if there is at least one argument
@@ -600,7 +602,7 @@ export class SchemaParser {
           name: propertyName,
           type: {
             ...fieldDef,
-            description: this.getTypeDocumentation(fieldType)
+            description: this.getSymbolDocumentation(property.symbol)
           },
           args: []
         }
@@ -971,6 +973,7 @@ export class SchemaParser {
             referenceSchema[processing].get(type)![
               property.escapedName as string
             ] = {
+              symbol: property,
               returnType: propertyType,
               args: {}
             }


### PR DESCRIPTION
Fix an issue where field descriptions in schema parsing did not work.

Previously, field descriptions (e.g., for interface fields) were not included in the generated schema, as the return type's description was incorrectly used instead of the field's own comments.

Now, field descriptions are correctly parsed from property symbols, ensuring that inline comments are reflected in the generated schema.

**Example:**

```typescript
interface Greeting {
  /**
   *  Profile of the user
   */
  profile: string;
  /** Matching status */
  matching: string;
  /** Date of the greeting */
  date: Date;
}
````

In the above example, the `profile`, `matching`, and `date` fields will now include their respective descriptions in the generated schema.