### PR TITLE
fix(config): add logger and graphiql options to config

### DIFF
--- a/.changeset/twenty-cobras-sip.md
+++ b/.changeset/twenty-cobras-sip.md
@@ -1,0 +1,12 @@
+---
+"@getcronit/pylon": patch
+---
+
+fix(config): add logger and graphiql options to config
+
+```ts
+export const config: PylonConfig = {
+  logger: false, // Disables the default logger
+  graphiql: false // Disables `graphiql` (Playground) and `viewer`
+}
+```

--- a/packages/pylon/src/app/index.ts
+++ b/packages/pylon/src/app/index.ts
@@ -1,10 +1,7 @@
 import {Hono} from 'hono'
-import {logger} from 'hono/logger'
 import {sentry} from '@hono/sentry'
 
 import {asyncContext, Env} from '../context'
-import {graphqlViewerHandler} from './handler/graphql-viewer-handler'
-
 export const app = new Hono<Env>()
 
 app.use('*', sentry())
@@ -21,12 +18,8 @@ app.use('*', async (c, next) => {
   })
 })
 
-app.use('*', logger())
-
 app.use((c, next) => {
   // @ts-ignore
   c.req.id = crypto.randomUUID()
   return next()
 })
-
-app.get('/viewer', graphqlViewerHandler)

--- a/packages/pylon/src/index.ts
+++ b/packages/pylon/src/index.ts
@@ -18,7 +18,13 @@ export {getEnv} from './get-env.js'
 export {createDecorator} from './create-decorator.js'
 export {createPubSub as experimentalCreatePubSub} from 'graphql-yoga'
 
-export type PylonConfig = Pick<YogaServerOptions<Context, Context>, 'plugins'>
+export type PylonConfig = Pick<
+  YogaServerOptions<Context, Context>,
+  'plugins'
+> & {
+  logger?: boolean
+  graphiql?: boolean
+}
 
 export type ID = string & {readonly brand?: unique symbol}
 export type Int = number & {readonly brand?: unique symbol}


### PR DESCRIPTION
This pull request introduces middleware configuration options and refactors imports in the `pylon` package. The most significant changes include adding support for enabling/disabling logging and GraphiQL via the `PylonConfig` interface, updating middleware initialization in the `pylon-handler`, and reorganizing imports for better readability.

### Middleware Configuration Enhancements:

* [`packages/pylon/src/index.ts`](diffhunk://#diff-6617c2453fdd4b4b9d84b2fc2a3ab0585a0d05eb1a2f268aeecf2768204784b4L21-R27): Extended the `PylonConfig` type to include `logger` and `graphiql` options, allowing users to enable or disable middleware features.
* [`packages/pylon/src/app/handler/pylon-handler.ts`](diffhunk://#diff-df9ddc607cec0f5ee1f204aee4dd3a742039f4e94f2b6b22fa08f24d9f3ecb44R122-R129): Added conditional middleware initialization for logging and GraphiQL based on the `PylonConfig` settings.

### Import Reorganization:

* [`packages/pylon/src/app/handler/pylon-handler.ts`](diffhunk://#diff-df9ddc607cec0f5ee1f204aee4dd3a742039f4e94f2b6b22fa08f24d9f3ecb44L1-R17): Reorganized imports to improve readability and maintain alphabetical order.
* [`packages/pylon/src/app/index.ts`](diffhunk://#diff-28b8f82a84393c4bf65657ae949eada4670c576dd10d430b9d728558c82bae34L2-L7): Removed unused imports (`logger` and `graphqlViewerHandler`) and simplified the file. [[1]](diffhunk://#diff-28b8f82a84393c4bf65657ae949eada4670c576dd10d430b9d728558c82bae34L2-L7) [[2]](diffhunk://#diff-28b8f82a84393c4bf65657ae949eada4670c576dd10d430b9d728558c82bae34L24-L32)