### PR TITLE
fix: merge interface fields into derived types in SDL generation

### DIFF
--- a/packages/pylon-dev/src/builder/schema/schema-parser.ts
+++ b/packages/pylon-dev/src/builder/schema/schema-parser.ts
@@ -317,6 +317,20 @@ export class SchemaParser {
               if (!derivedSchemaType.implements.includes(interfaceName)) {
                 derivedSchemaType.implements.push(interfaceName)
               }
+
+              // Ensure the derived type includes all interface fields.
+              // Without this, GraphQL schema validation fails:
+              // "Interface field IFoo.x expected but Bar does not provide it."
+              if (targetInterface) {
+                for (const ifaceField of targetInterface.fields) {
+                  const alreadyHasField = derivedSchemaType.fields.some(
+                    f => f.name === ifaceField.name
+                  )
+                  if (!alreadyHasField) {
+                    derivedSchemaType.fields.push({...ifaceField})
+                  }
+                }
+              }
             }
 
             // Check if this derived type is also a base type for other types


### PR DESCRIPTION
## Summary

Fixes #110 — inherited/implemented fields are not included in the SDL for derived types, causing GraphQL schema validation to fail at runtime.

## Problem

When `class Traffic extends RegionNode`, Pylon correctly:
1. Detects the inheritance relationship
2. Creates the `IRegionNode` interface with all fields
3. Adds `implements IRegionNode` to `Traffic`

But it does **not** copy the interface fields into `Traffic`'s field list in the SDL. GraphQL-js `validateSchema` then fails:

```
Interface field IRegionNode.id expected but Traffic does not provide it.
```

## Fix

In `addInterfaceToDerived` (schema-parser.ts), after adding the `implements` clause, merge all interface fields into the derived type's field list (skipping fields already declared on the derived type).

```typescript
if (targetInterface) {
  for (const ifaceField of targetInterface.fields) {
    const alreadyHasField = derivedSchemaType.fields.some(
      f => f.name === ifaceField.name
    )
    if (!alreadyHasField) {
      derivedSchemaType.fields.push({...ifaceField})
    }
  }
}
```

## Test plan

- All 22 existing schema tests pass (inheritance, generics, basic-features, inputs-and-args)
- Verified at runtime on Cloudflare Workers with a real-world GTFS GraphQL API using `Traffic extends RegionNode` and `Tourism extends RegionNode`
